### PR TITLE
Add ability to configure HTTP Basic auth for Nginx

### DIFF
--- a/nginx/attributes/nginx.rb
+++ b/nginx/attributes/nginx.rb
@@ -37,6 +37,8 @@ end
 
 default[:nginx][:log_format] = {}
 
+default[:nginx][:auth_basic_user_file] = "conf.d/htpasswd"
+
 # increase if you accept large uploads
 default[:nginx][:client_max_body_size] = "4m"
 

--- a/nginx/metadata.rb
+++ b/nginx/metadata.rb
@@ -24,6 +24,20 @@ attribute "nginx/binary",
   :description => "Location of the nginx server binary",
   :default => "/usr/sbin/nginx"
 
+# http://nginx.org/en/docs/http/ngx_http_auth_basic_module.html
+attribute "nginx/auth_basic",
+  :display_name => "Nginx HTTP Basic Authentication",
+  :description => "Enable use of HTTP Basic Auth. Parameter is the realm to use."
+
+attribute "nginx/auth_basic_user_file",
+  :display_name => "Nginx HTTP Basic Auth Password File",
+  :description => "File to look up HTTP Basic Auth credentials in",
+  :default => "conf.d/htpasswd"
+
+attribute "nginx/auth_basic_credentials",
+  :display_name => "Nginx HTTP Basic Auth Credentials",
+  :description => "Username and password used to access site. Assumes single."
+
 attribute "nginx/gzip",
   :display_name => "Nginx Gzip",
   :description => "Whether gzip is enabled",

--- a/nginx/recipes/default.rb
+++ b/nginx/recipes/default.rb
@@ -57,6 +57,16 @@ template "nginx.conf" do
   mode 0644
 end
 
+if node[:nginx][:auth_basic]
+  template "htpasswd" do
+    path "#{node[:nginx][:dir]}/conf.d/htpasswd"
+    source "htpasswd.erb"
+    owner "root"
+    group "root"
+    mode 0644
+  end
+end
+
 template "#{node[:nginx][:dir]}/sites-available/default" do
   source "default-site.erb"
   owner "root"

--- a/nginx/templates/default/htpasswd.erb
+++ b/nginx/templates/default/htpasswd.erb
@@ -1,0 +1,1 @@
+<%= node[:nginx][:auth_basic_credentials] %>

--- a/nginx/templates/default/nginx.conf.erb
+++ b/nginx/templates/default/nginx.conf.erb
@@ -22,6 +22,11 @@ http {
   tcp_nopush on;
   tcp_nodelay on;
 
+  <% if node[:nginx][:auth_basic] %>
+  auth_basic           <%= node[:nginx][:auth_basic] %>;
+  auth_basic_user_file <%= node[:nginx][:auth_basic_user_file] %>;
+  <% end %>
+
   <% if node[:nginx][:keepalive] == "on" %>
   keepalive_timeout  <%= node[:nginx][:keepalive_timeout] %>;
   <% end %>


### PR DESCRIPTION
Override the default `nginx` recipes to allow for http basic auth.

/cc @charlespeach 
