### PR TITLE
Add redirection commands to nginx site config

### DIFF
--- a/unicorn/templates/default/nginx_unicorn_web_app.erb
+++ b/unicorn/templates/default/nginx_unicorn_web_app.erb
@@ -111,3 +111,12 @@ server {
   }
 }
 <% end %>
+
+# Redirect a list of domains to the canonical domain.
+<% @application[:redirect_domains].each do |domain| -%>
+server {
+  listen 80;
+  server_name .<%= domain %>;
+  return 301 $scheme://<%= @application[:domains].first %>$request_uri;
+}
+<% end -%>


### PR DESCRIPTION
If redirect domains are provided, add 301 permanent redirect handlers
to the site’s nginx configuration.
